### PR TITLE
Fix GitHub Pages config to use DiyiLiu.github.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,9 +11,9 @@ title                    : "Diyi Liu"
 title_separator          : "-"
 name                     : &name "Diyi Liu"
 description              : &description "Postdoctoral Researcher - Lawrence Berkeley National Laboratory"
-url                      : https://Diyi2020.github.io # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
+url                      : https://DiyiLiu.github.io # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : "" # the subpath of your site, e.g. "/blog"
-repository               : "Diyi2020/Diyi2020.github.io"
+repository               : "DiyiLiu/DiyiLiu.github.io"
 teaser                   :  # filename of teaser fallback teaser image placed in /images/, .e.g. "500x300.png"
 breadcrumbs              : false # true, false (default)
 words_per_minute         : 160
@@ -96,7 +96,7 @@ author:
   flickr           :
   facebook         :
   foursquare       :
-  github           : "Diyi2020"
+  github           : "DiyiLiu"
   google_plus      :
   keybase          :
   instagram        :


### PR DESCRIPTION
### Motivation
- Fix site deployment and generated links by correcting identity fields in `_config.yml` that still pointed to the previous username.

### Description
- Updated `_config.yml` to set `url` to `https://DiyiLiu.github.io`, `repository` to `DiyiLiu/DiyiLiu.github.io`, and `author.github` to `DiyiLiu`.

### Testing
- Attempted to run `bundle exec jekyll build` to validate the site build but it failed in this environment with `bundler: command not found: jekyll`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad3b79e8c83238077c76ebeddfadf)